### PR TITLE
Switch to new-style user managed_home

### DIFF
--- a/definitions/daemon_user.rb
+++ b/definitions/daemon_user.rb
@@ -61,7 +61,7 @@ define(:daemon_user,
     password      nil
     shell         params[:shell]
     home          params[:home]
-    supports      :manage_home => false # you must create standard dirs yourself
+    manage_home   false # you must create standard dirs yourself
     action        params[:action]
   end
 


### PR DESCRIPTION
```
         supports { manage_home: false } on the user resource is deprecated and will be removed in Chef 13, set manage_home: false instead at 1 location:
           - /tmp/kitchen/cache/cookbooks/metachef/definitions/daemon_user.rb:64:in `block (2 levels) in from_file'
```
